### PR TITLE
feat(capsules): add leaf capability capsule behind feature flag

### DIFF
--- a/src/capsules/CapsuleLeafCapability.tsx
+++ b/src/capsules/CapsuleLeafCapability.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { capsuleRegistry } from "./registry";
+
+export const CapsuleLeafCapability: React.FC<{
+  spec: any;
+  onSelectLeafModel: (id: string) => void;
+}> = ({ spec, onSelectLeafModel }) => {
+  const cap = capsuleRegistry.find(c => c.name === "leaf-capability-filter")!;
+  const input = {
+    endpointProfiles: spec?.endpointProfiles ?? [],
+    uplinksPerLeaf: Number(spec?.uplinksPerLeaf ?? 0),
+  };
+  const [result, setResult] = React.useState<any>(null);
+
+  return (
+    <cap.Panel
+      input={input}
+      result={result}
+      onRun={(i) => setResult(cap.run(i))}
+      onSelect={onSelectLeafModel}
+    />
+  );
+};
+

--- a/src/capsules/leaf-capability-filter/Panel.tsx
+++ b/src/capsules/leaf-capability-filter/Panel.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import type { Input, Output } from "./engine";
+
+export const LeafCapabilityPanel: React.FC<{
+  input: Input;
+  result?: Output;
+  onRun: (input: Input) => void;
+  onSelect: (leafModelId: string) => void;
+}> = ({ input, result, onRun, onSelect }) => (
+  <div style={{border:"1px solid #ddd", borderRadius:8, padding:12}}>
+    <div style={{display:"flex", gap:8, alignItems:"center", marginBottom:8}}>
+      <strong>Leaf Capability Capsule</strong>
+      <button onClick={() => onRun(input)}>Compute</button>
+    </div>
+    {result && (
+      <>
+        <div style={{marginBottom:6}}>Viable models:</div>
+        <ul>
+          {result.viableModels.map(id => (
+            <li key={id}>
+              {id} <button onClick={() => onSelect(id)}>Select</button>
+            </li>
+          ))}
+        </ul>
+        {!!result.warnings?.length && (
+          <div style={{marginTop:8, fontSize:12, color:"#8a6d3b"}}>
+            ⚠ {result.warnings.join(", ")}
+          </div>
+        )}
+      </>
+    )}
+  </div>
+);
+

--- a/src/capsules/leaf-capability-filter/engine.ts
+++ b/src/capsules/leaf-capability-filter/engine.ts
@@ -1,0 +1,16 @@
+import { checkLeafCapability, DEFAULT_LEAF_MODELS } from "@/domain/leaf-capability-filter";
+import type { EndpointProfile } from "@/components/gfd/MultiProfileEndpointEditor";
+
+export type Input = { endpointProfiles: EndpointProfile[]; uplinksPerLeaf: number };
+export type Output = { viableModels: string[]; warnings: string[] };
+
+export function run(input: Input): Output {
+  const warnings: string[] = [];
+  const viable = DEFAULT_LEAF_MODELS
+    .map(m => ({ m, res: checkLeafCapability(m, input.endpointProfiles ?? [], input.uplinksPerLeaf ?? 0) }))
+    .filter(x => x.res.feasible);
+
+  for (const v of viable) if (v.res.warnings?.length) warnings.push(...v.res.warnings);
+  return { viableModels: viable.map(v => v.m.id), warnings };
+}
+

--- a/src/capsules/registry.ts
+++ b/src/capsules/registry.ts
@@ -1,0 +1,12 @@
+import { run as runLeafCap } from "./leaf-capability-filter/engine";
+import { LeafCapabilityPanel } from "./leaf-capability-filter/Panel";
+
+export const capsuleRegistry = [
+  {
+    name: "leaf-capability-filter",
+    slot: "gfd/02-leaf-model",
+    run: runLeafCap,
+    Panel: LeafCapabilityPanel,
+  },
+] as const;
+

--- a/src/components/FabricDesignerView.tsx
+++ b/src/components/FabricDesignerView.tsx
@@ -13,6 +13,7 @@ import { BreakoutBadge } from '../ui/BreakoutBadge'
 import HistoryView from './HistoryView'
 import { BulkOperationsPanel } from './BulkOperationsPanel'
 import StepperView from './gfd/StepperView'
+import { CapsuleLeafCapability } from '@/capsules/CapsuleLeafCapability'
 
 export const FabricDesignerView: React.FC = () => {
   const [state, send] = useMachine(fabricDesignMachine, {})
@@ -28,6 +29,12 @@ export const FabricDesignerView: React.FC = () => {
     return qp === 'true' || localStorage.getItem('FEATURE_GFD') === 'true'
   }, [])
   const [activeTab, setActiveTab] = useState<'quick' | 'guided'>(gfdEnabled ? 'guided' : 'quick')
+
+  // --- Capsules mount (feature-flagged) ---
+  const capsulesOn =
+    typeof window !== 'undefined' &&
+    (new URLSearchParams(window.location.search).get('FEATURE_CAPSULES') === 'true' ||
+      window.localStorage.getItem('FEATURE_CAPSULES') === 'true')
   
   const handleInputChange = (field: string, value: any) => {
     send({ type: 'UPDATE_CONFIG', data: { [field]: value } })
@@ -697,6 +704,17 @@ export const FabricDesignerView: React.FC = () => {
         isOpen={isHistoryViewOpen}
         onClose={handleCloseHistory}
       />
+      {capsulesOn && (
+        <section style={{ marginTop: 16 }}>
+          <h3>Capsules</h3>
+          <CapsuleLeafCapability
+            spec={config}
+            onSelectLeafModel={(id) =>
+              send({ type: 'UPDATE_CONFIG', data: { leafModelId: id } })
+            }
+          />
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add leaf capability capsule engine, panel, registry, and wrapper
- mount capsule in FabricDesignerView behind `FEATURE_CAPSULES`

## Testing
- `npm test` *(fails: Failed to resolve imports e.g., `@testing-library/react`, `isomorphic-git`)*

------
https://chatgpt.com/codex/tasks/task_e_68b93bceda68832bbae929949eaa487a